### PR TITLE
bumps lodash.merge version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/estate/bookshelf-uuid#readme",
   "dependencies": {
-    "lodash.merge": "^4.3.5",
+    "lodash.merge": "^4.6.2",
     "lodash.result": "^4.3.0",
     "uuid": "^2.0.2"
   },


### PR DESCRIPTION
Current version 4.3.5 is vulnerable to CVE-2019-10744 (https://github.com/lodash/lodash/pull/4336). Updates lodash.merge version to 4.6.2.